### PR TITLE
Relax MessageReader API to accept ArrayBufferView

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "typescript": "4.3.5"
   },
   "dependencies": {
-    "@foxglove/cdr": "^1.1.1",
+    "@foxglove/cdr": "^1.2.0",
     "@foxglove/rosmsg": "^2.0.0",
     "@foxglove/rostime": "^1.1.0"
   }

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -38,7 +38,7 @@ export class MessageReader<T = unknown> {
 
   // We template on R here for call site type information if the class type information T is not
   // known or available
-  readMessage<R = T>(buffer: Readonly<Uint8Array>): R {
+  readMessage<R = T>(buffer: ArrayBufferView): R {
     const reader = new CdrReader(buffer);
     return this.readComplexType(this.rootDefinition, reader) as R;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,10 +324,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@foxglove/cdr@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@foxglove/cdr/-/cdr-1.1.1.tgz#c0a77713ba67b2ed6feaf5f64fa8c50fe713534d"
-  integrity sha512-Bv5bjHCh4K3x8OdBvt/0W+EEUIrDlM7+rLj2/LpguUXET51EsBVACCzYRvvZtQdAkJUZxVhuRnI3e8+rISWNcg==
+"@foxglove/cdr@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/cdr/-/cdr-1.2.0.tgz#b8c69b37299ae47bb3ffc0f0eef70d99cf9a0a4b"
+  integrity sha512-KuPGicuOPA4U5Y+a3YfHe6prQhbDlI6zxaIYhhKhF+2/qTophkOemJEqbJcAOfy1rim7+O5n2S9ATPK63C9GPw==
 
 "@foxglove/eslint-plugin@0.14.0":
   version "0.14.0"


### PR DESCRIPTION
**Public-Facing Changes**
- `readMessage` now accepts any ArrayBufferView (including Uint8Array and DataView).
