### PR TITLE
Fix serde of empty message definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ROS 2 (Robot Operating System) message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -477,4 +477,27 @@ module builtin_interfaces {
       ],
     });
   });
+
+  it("should deserialize an empty ROS 2 msg (e.g. std_msgs/msg/Empty)", () => {
+    const buffer = Uint8Array.from(Buffer.from("0001000000", "hex"));
+    const msgDef = ``;
+    const reader = new MessageReader(parseMessageDefinition(msgDef, { ros2: true }));
+    const read = reader.readMessage(buffer);
+
+    expect(read).toEqual({});
+  });
+
+  it("should deserialize a custom msg with a std_msgs/msg/Empty field", () => {
+    const buffer = Uint8Array.from(Buffer.from("00010000000000007b000000", "hex"));
+    const msgDef = `
+    std_msgs/msg/Empty empty
+    int32 int_32_field
+    ================================================================================
+    MSG: std_msgs/msg/Empty
+    `;
+    const reader = new MessageReader(parseMessageDefinition(msgDef, { ros2: true }));
+    const read = reader.readMessage(buffer);
+
+    expect(read).toEqual({ empty: {}, int_32_field: 123 });
+  });
 });

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -48,6 +48,16 @@ export class MessageReader<T = unknown> {
     reader: CdrReader,
   ): Record<string, unknown> {
     const msg: Record<string, unknown> = {};
+
+    if (definition.length === 0) {
+      // In case a message definition definition is empty, ROS 2 adds a
+      // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
+      // to satisfy the requirement from IDL of not being empty.
+      // See also https://design.ros2.org/articles/legacy_interface_definition.html
+      reader.uint8();
+      return msg;
+    }
+
     for (const field of definition) {
       if (field.isConstant === true) {
         continue;

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -482,4 +482,31 @@ module builtin_interfaces {
     expect(written).toBytesEqual(expected);
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });
+
+  it("should serialize an empty ROS 2 msg (e.g. std_msgs/msg/Empty)", () => {
+    const expected = Uint8Array.from(Buffer.from("0001000000", "hex"));
+    const msgDef = ``;
+    const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
+    const message = {};
+    const written = writer.writeMessage(message);
+
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
+
+  it("should serialize a custom msg with a std_msgs/msg/Empty field", () => {
+    const expected = Uint8Array.from(Buffer.from("00010000000000007b000000", "hex"));
+    const msgDef = `
+    std_msgs/msg/Empty empty
+    int32 int_32_field
+    ================================================================================
+    MSG: std_msgs/msg/Empty
+    `;
+    const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
+    const message = { int_32_field: 123 };
+    const written = writer.writeMessage(message);
+
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
 });

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -102,6 +102,14 @@ export class MessageWriter {
     const messageObj = message as Record<string, unknown> | undefined;
     let newOffset = offset;
 
+    if (definition.length === 0) {
+      // In case a message definition definition is empty, ROS 2 adds a
+      // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
+      // to satisfy the requirement from IDL of not being empty.
+      // See also https://design.ros2.org/articles/legacy_interface_definition.html
+      return offset + this.getPrimitiveSize("uint8");
+    }
+
     for (const field of definition) {
       if (field.isConstant === true) {
         continue;
@@ -167,6 +175,15 @@ export class MessageWriter {
 
   private write(definition: MessageDefinitionField[], message: unknown, writer: CdrWriter): void {
     const messageObj = message as Record<string, unknown> | undefined;
+
+    if (definition.length === 0) {
+      // In case a message definition definition is empty, ROS 2 adds a
+      // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
+      // to satisfy the requirement from IDL of not being empty.
+      // See also https://design.ros2.org/articles/legacy_interface_definition.html
+      uint8(0, 0, writer);
+      return;
+    }
 
     for (const field of definition) {
       if (field.isConstant === true) {


### PR DESCRIPTION
### Public-Facing Changes

Fix serde of empty message definition

### Description
In case a message definition definition is empty, ROS 2 adds a `uint8 structure_needs_at_least_one_member` field when converting to IDL, to satisfy the requirement from IDL of not being empty. See also
https://design.ros2.org/articles/legacy_interface_definition.html

This patch inserts or skips that extra member when serializing or deserializing respectively.

Replaces https://github.com/foxglove/rosmsg/pull/34, to avoid that the `structure_needs_at_least_one_member` is being displayed.
