### PR TITLE
Add Time/Duration from `builtin_interfaces` to builtin serde

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ROS 2 (Robot Operating System) message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "ROS 2 (Robot Operating System) message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -1,3 +1,4 @@
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition, parseRos2idl } from "@foxglove/rosmsg";
 
 import { MessageReader } from "./MessageReader";
@@ -499,5 +500,28 @@ module builtin_interfaces {
     const read = reader.readMessage(buffer);
 
     expect(read).toEqual({ empty: {}, int_32_field: 123 });
+  });
+
+  it.each([
+    [
+      `time`,
+      `builtin_interfaces/Time`,
+      `builtin_interfaces/msg/Time`,
+      `duration`,
+      `builtin_interfaces/Duration`,
+      `builtin_interfaces/msg/Duration`,
+    ],
+  ])("should deserialize time/duration primitive %s", (timePrimitive: string) => {
+    const arr = [0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00];
+    const buffer = Uint8Array.from([0, 1, 0, 0, ...arr]);
+    const expected = { stamp: { sec: 0, nsec: 1 } };
+    const msgDefs: MessageDefinition[] = [
+      {
+        definitions: [{ name: "stamp", type: timePrimitive, isComplex: false }],
+      },
+    ];
+    const reader = new MessageReader(msgDefs);
+    const read = reader.readMessage(buffer);
+    expect(read).toEqual(expected);
   });
 });

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -104,6 +104,8 @@ export class MessageReader<T = unknown> {
   }
 }
 
+const timeDeserializer: Deserializer = (reader) => ({ sec: reader.int32(), nsec: reader.uint32() });
+
 const deserializers = new Map<string, Deserializer>([
   ["bool", (reader) => Boolean(reader.int8())],
   ["int8", (reader) => reader.int8()],
@@ -117,8 +119,12 @@ const deserializers = new Map<string, Deserializer>([
   ["float32", (reader) => reader.float32()],
   ["float64", (reader) => reader.float64()],
   ["string", (reader) => reader.string()],
-  ["time", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
-  ["duration", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
+  ["time", timeDeserializer],
+  ["builtin_interfaces/Time", timeDeserializer],
+  ["builtin_interfaces/msg/Time", timeDeserializer],
+  ["duration", timeDeserializer],
+  ["builtin_interfaces/Duration", timeDeserializer],
+  ["builtin_interfaces/msg/Duration", timeDeserializer],
 ]);
 
 const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
@@ -135,7 +141,11 @@ const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
   ["float64", (reader, count) => reader.float64Array(count)],
   ["string", readStringArray],
   ["time", readTimeArray],
+  ["builtin_interfaces/Time", readTimeArray],
+  ["builtin_interfaces/msg/Time", readTimeArray],
   ["duration", readTimeArray],
+  ["builtin_interfaces/Duration", readTimeArray],
+  ["builtin_interfaces/msg/Duration", readTimeArray],
 ]);
 
 function readBoolArray(reader: CdrReader, count: number): boolean[] {

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -1,3 +1,4 @@
+import { MessageDefinition } from "@foxglove/message-definition";
 import { parse as parseMessageDefinition, parseRos2idl } from "@foxglove/rosmsg";
 
 import { MessageWriter } from "./MessageWriter";
@@ -506,6 +507,29 @@ module builtin_interfaces {
     const message = { int_32_field: 123 };
     const written = writer.writeMessage(message);
 
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
+
+  it.each([
+    [
+      `time`,
+      `builtin_interfaces/Time`,
+      `builtin_interfaces/msg/Time`,
+      `duration`,
+      `builtin_interfaces/Duration`,
+      `builtin_interfaces/msg/Duration`,
+    ],
+  ])("should serialize time/duration primitive %s", (timePrimitive: string) => {
+    const expected = Uint8Array.from(Buffer.from("00010000fb65865e80faae06", "hex"));
+    const msgDefs: MessageDefinition[] = [
+      {
+        definitions: [{ name: "stamp", type: timePrimitive, isComplex: false }],
+      },
+    ];
+    const writer = new MessageWriter(msgDefs);
+    const message = { stamp: { sec: 1585866235, nsec: 112130688 } };
+    const written = writer.writeMessage(message);
     expect(written).toBytesEqual(expected);
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -39,7 +39,11 @@ const PRIMITIVE_WRITERS = new Map<string, PrimitiveWriter>([
   ["float64", float64],
   ["string", string],
   ["time", time],
+  ["builtin_interfaces/Time", time],
+  ["builtin_interfaces/msg/Time", time],
   ["duration", time],
+  ["builtin_interfaces/Duration", time],
+  ["builtin_interfaces/msg/Duration", time],
 ]);
 
 const PRIMITIVE_ARRAY_WRITERS = new Map<string, PrimitiveArrayWriter>([
@@ -56,7 +60,11 @@ const PRIMITIVE_ARRAY_WRITERS = new Map<string, PrimitiveArrayWriter>([
   ["float64", float64Array],
   ["string", stringArray],
   ["time", timeArray],
+  ["builtin_interfaces/Time", timeArray],
+  ["builtin_interfaces/msg/Time", timeArray],
   ["duration", timeArray],
+  ["builtin_interfaces/Duration", timeArray],
+  ["builtin_interfaces/msg/Duration", timeArray],
 ]);
 
 /**


### PR DESCRIPTION
### Public-Facing Changes

- Add `builtin_interfaces/Time` and `builtin_interfaces/Duration` to builtin serializers / deserializers

### Description
This PR adds the `builtin_interfaces/Time` and `builtin_interfaces/Duration` to the builtin serializers / deserializers as a fallback in case these type names were not normalized to `time` / `duration` as it is usually the case when using [@foxglove/rosmsg](https://github.com/foxglove/rosmsg/blob/ea2e308ca666ae9a9539b1e336ccf9730a14f15e/src/buildRos2Type.ts#L204-L209). 

Fixes https://github.com/foxglove/studio/issues/6250 once applied to Foxglove Studio. Here the message definitions for foxglove schemas are generated using [generateRosMsgDefinition(schema, { rosVersion: 2 })](https://github.com/foxglove/rosbag2/blob/7af44e3338ad715204d3534a6bbdf52c83960852/src/Rosbag2.ts#L23-L25) which converts `time` to `builtin_interfaces/Time`

