### PR TITLE
Fix constant modules first declared from being used as the root definition

### DIFF
--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -500,4 +500,24 @@ module builtin_interfaces {
 
     expect(read).toEqual({ empty: {}, int_32_field: 123 });
   });
+
+  it("ros2idl should choose non-constant root definition", () => {
+    const data = [0x02];
+    const buffer = Uint8Array.from([0, 1, 0, 0, ...data]);
+    const msgDef = `
+    module a {
+      module b {
+        const int8 STATUS_ONE = 1;
+        const int8 STATUS_TWO = 2;
+      };
+      struct c {
+       int8 status;
+      };
+    };
+    `;
+    const reader = new MessageReader(parseRos2idl(msgDef));
+    const read = reader.readMessage(buffer);
+
+    expect(read).toEqual({ status: 2 });
+  });
 });

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -26,7 +26,9 @@ export class MessageReader<T = unknown> {
   definitions: Map<string, MessageDefinitionField[]>;
 
   constructor(definitions: MessageDefinition[]) {
-    const rootDefinition = definitions[0];
+    // ros2idl modules could have constant modules before the root struct used to decode message
+    const rootDefinition = definitions.find((def) => !isConstantModule(def));
+
     if (rootDefinition == undefined) {
       throw new Error("MessageReader initialized with no root MessageDefinition");
     }
@@ -102,6 +104,10 @@ export class MessageReader<T = unknown> {
     }
     return msg;
   }
+}
+
+function isConstantModule(def: MessageDefinition): boolean {
+  return def.definitions.length > 0 && def.definitions.every((field) => field.isConstant);
 }
 
 const deserializers = new Map<string, Deserializer>([

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -509,4 +509,28 @@ module builtin_interfaces {
     expect(written).toBytesEqual(expected);
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });
+
+  it("ros2idl should choose non-constant root definition", () => {
+    const message = { status: 2 };
+    const messageBin = [0x02];
+    const msgDef = `
+    module a {
+      module b {
+        const int8 STATUS_ONE = 1;
+        const int8 STATUS_TWO = 2;
+      };
+      struct c {
+       int8 status;
+      };
+    };
+    `;
+
+    const expected = Uint8Array.from([0, 1, 0, 0, ...messageBin]);
+
+    const writer = new MessageWriter(parseRos2idl(msgDef));
+    const written = writer.writeMessage(message);
+
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
 });

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -68,7 +68,8 @@ export class MessageWriter {
   definitions: Map<string, MessageDefinitionField[]>;
 
   constructor(definitions: MessageDefinition[]) {
-    const rootDefinition = definitions[0];
+    // ros2idl modules could have constant modules before the root struct used to decode message
+    const rootDefinition = definitions.find((def) => !isConstantModule(def));
     if (rootDefinition == undefined) {
       throw new Error("MessageReader initialized with no root MessageDefinition");
     }
@@ -260,6 +261,10 @@ export class MessageWriter {
     }
     return writer;
   }
+}
+
+function isConstantModule(def: MessageDefinition): boolean {
+  return def.definitions.length > 0 && def.definitions.every((field) => field.isConstant);
 }
 
 function fieldLength(value: unknown): number {


### PR DESCRIPTION
The reason the `AutowareState` schema wasn't showing up was because it has a module within the parent module of the root definition struct filled with constants that was being used as the root definition in the message serializer. I've added a `isConstantModule` function to prevent this from being used as the root schema in the serializers

<img width="513" alt="image" src="https://github.com/foxglove/rosmsg2-serialization/assets/10187776/def0bd5c-998a-4a67-abae-7d24e9ea8729">


https://linear.app/foxglove/issue/FG-3938/autoware-auto-system-msgsmsgautowarestate-is-read-as-an-empty-object