### PR TITLE
Fix incorrect serialization of fixed-length arrays

### DIFF
--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -534,23 +534,30 @@ module builtin_interfaces {
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });
 
-  it("should default initialize a fixed-length array", () => {
-    const msgDef = [
-      {
-        definitions: [
-          {
-            type: "float64",
-            name: "array",
-            isArray: true,
-            arrayLength: 10,
-          },
-        ],
-      },
-    ];
-    const msgWriter = new MessageWriter(msgDef);
-    const written = msgWriter.writeMessage({});
-    expect(written.byteLength).toEqual(84);
-  });
+  it.each([
+    ["float64", 10, 84],
+    ["time", 10, 84],
+    ["uint8", 5, 9],
+  ])(
+    "should default initialize a fixed-length %s array",
+    (type, arrayLength, expectedByteLength) => {
+      const msgDef = [
+        {
+          definitions: [
+            {
+              type,
+              name: "array",
+              isArray: true,
+              arrayLength,
+            },
+          ],
+        },
+      ];
+      const msgWriter = new MessageWriter(msgDef);
+      const written = msgWriter.writeMessage({});
+      expect(written.byteLength).toEqual(expectedByteLength);
+    },
+  );
 
   it("should throw when writing an array with wrong size to fixed-length array", () => {
     const msgDef = [

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -533,4 +533,43 @@ module builtin_interfaces {
     expect(written).toBytesEqual(expected);
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });
+
+  it("should default initialize a fixed-length array", () => {
+    const msgDef: MessageDefinition[] = [
+      {
+        definitions: [
+          {
+            type: "float64",
+            name: "array",
+            isArray: true,
+            arrayLength: 10,
+          },
+        ],
+      },
+    ];
+    const msgWriter = new MessageWriter(msgDef);
+    const written = msgWriter.writeMessage({});
+    expect(written.byteLength).toEqual(84);
+  });
+
+  it("should throw when writing an array with wrong size to fixed-length array", () => {
+    const msgDef: MessageDefinition[] = [
+      {
+        definitions: [
+          {
+            type: "float64",
+            name: "array",
+            isArray: true,
+            arrayLength: 10,
+          },
+        ],
+      },
+    ];
+    const msgWriter = new MessageWriter(msgDef);
+    expect(() => msgWriter.writeMessage({ array: [] })).toThrow();
+    expect(() => msgWriter.writeMessage({ array: new Float64Array() })).toThrow();
+    expect(() => msgWriter.writeMessage({ array: new Float64Array(5) })).toThrow();
+    expect(() => msgWriter.writeMessage({ array: new Float64Array(10) })).not.toThrow();
+    expect(() => msgWriter.writeMessage({ array: new Array(10).fill(0) })).not.toThrow();
+  });
 });

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -535,7 +535,7 @@ module builtin_interfaces {
   });
 
   it("should default initialize a fixed-length array", () => {
-    const msgDef: MessageDefinition[] = [
+    const msgDef = [
       {
         definitions: [
           {
@@ -553,7 +553,7 @@ module builtin_interfaces {
   });
 
   it("should throw when writing an array with wrong size to fixed-length array", () => {
-    const msgDef: MessageDefinition[] = [
+    const msgDef = [
       {
         definitions: [
           {

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -217,7 +217,7 @@ export class MessageWriter {
           const givenFieldLength = fieldLength(nestedMessage);
           if (givenFieldLength !== field.arrayLength) {
             throw new Error(
-              `Given array does not match the defined array size: ${givenFieldLength} != ${field.arrayLength}`,
+              `Expected ${field.arrayLength} items for fixed-length array field ${field.name} but received ${givenFieldLength}`,
             );
           }
         }
@@ -561,10 +561,15 @@ function timeArray(
   value: unknown,
   _defaultValue: DefaultValue,
   writer: CdrWriter,
-  _arrayLength?: number,
+  arrayLength?: number,
 ): void {
   if (Array.isArray(value)) {
     for (const item of value) {
+      time(item, undefined, writer);
+    }
+  } else {
+    const array = new Array(arrayLength).fill(undefined) as undefined[];
+    for (const item of array) {
       time(item, undefined, writer);
     }
   }


### PR DESCRIPTION
### Public-Facing Changes

Fix incorrect serialization of fixed-length arrays

### Description
Makes sure that fixed-length arrays are default initialized if no value is given


Fixes #22 
Resolves FG-5529

