### PR TITLE
fix: update ros time to ros2 time

### DIFF
--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -57,7 +57,7 @@ describe("MessageReader", () => {
       {
         stamp: {
           sec: 0,
-          nsec: 1,
+          nanosec: 1,
         },
       },
     ],
@@ -67,7 +67,7 @@ describe("MessageReader", () => {
       {
         stamp: {
           sec: 0,
-          nsec: 1,
+          nanosec: 1,
         },
       },
     ],
@@ -82,22 +82,22 @@ describe("MessageReader", () => {
     [
       `time[1] arr`,
       [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
-      { arr: [{ sec: 1, nsec: 2 }] },
+      { arr: [{ sec: 1, nanosec: 2 }] },
     ],
     [
       `duration[1] arr`,
       [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
-      { arr: [{ sec: 1, nsec: 2 }] },
+      { arr: [{ sec: 1, nanosec: 2 }] },
     ],
     [
       `time[] arr`,
       [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
-      { arr: [{ sec: 2, nsec: 3 }] },
+      { arr: [{ sec: 2, nanosec: 3 }] },
     ],
     [
       `duration[] arr`,
       [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
-      { arr: [{ sec: 2, nsec: 3 }] },
+      { arr: [{ sec: 2, nanosec: 3 }] },
     ],
     // unaligned access
     [
@@ -117,7 +117,7 @@ describe("MessageReader", () => {
         ...[0x00, 0x00, 0x00], // alignment
         ...[0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
       ],
-      { blank: 0, arr: [{ sec: 2, nsec: 3 }] },
+      { blank: 0, arr: [{ sec: 2, nanosec: 3 }] },
     ],
     [`float32[2] arr`, float32Buffer([5.5, 6.5]), { arr: Float32Array.from([5.5, 6.5]) }],
     [
@@ -303,7 +303,7 @@ describe("MessageReader", () => {
     const read = reader.readMessage(buffer);
 
     expect(read).toEqual({
-      stamp: { sec: 1585866235, nsec: 112130688 },
+      stamp: { sec: 1585866235, nanosec: 112130688 },
       level: 20,
       name: "minimal_publisher",
       msg: "Publishing: 'Hello, world! 0'",
@@ -354,7 +354,7 @@ describe("MessageReader", () => {
       transforms: [
         {
           header: {
-            stamp: { sec: 1638821672, nsec: 836230505 },
+            stamp: { sec: 1638821672, nanosec: 836230505 },
             frame_id: "turtle1",
           },
           child_frame_id: "turtle1_ahead",

--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -275,6 +275,269 @@ describe("MessageReader", () => {
     },
   );
 
+  it.each([
+    [`int8 sample # lowest`, [0x80], { sample: -128 }],
+    [`int8 sample # highest`, [0x7f], { sample: 127 }],
+    [`uint8 sample # lowest`, [0x00], { sample: 0 }],
+    [`uint8 sample # highest`, [0xff], { sample: 255 }],
+    [`int16 sample # lowest`, [0x00, 0x80], { sample: -32768 }],
+    [`int16 sample # highest`, [0xff, 0x7f], { sample: 32767 }],
+    [`uint16 sample # lowest`, [0x00, 0x00], { sample: 0 }],
+    [`uint16 sample # highest`, [0xff, 0xff], { sample: 65535 }],
+    [`int32 sample # lowest`, [0x00, 0x00, 0x00, 0x80], { sample: -2147483648 }],
+    [`int32 sample # highest`, [0xff, 0xff, 0xff, 0x7f], { sample: 2147483647 }],
+    [`uint32 sample # lowest`, [0x00, 0x00, 0x00, 0x00], { sample: 0 }],
+    [`uint32 sample # highest`, [0xff, 0xff, 0xff, 0xff], { sample: 4294967295 }],
+    [
+      `int64 sample # lowest`,
+      [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80],
+      { sample: -9223372036854775808n },
+    ],
+    [
+      `int64 sample # highest`,
+      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x7f],
+      { sample: 9223372036854775807n },
+    ],
+    [`uint64 sample # lowest`, [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00], { sample: 0n }],
+    [
+      `uint64 sample # highest`,
+      [0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff],
+      { sample: 18446744073709551615n },
+    ],
+    [`float32 sample`, float32Buffer([5.5]), { sample: 5.5 }],
+    [
+      `float64 sample`,
+      // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+      new Uint8Array(Float64Array.of(0.123456789121212121212).buffer),
+      // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
+      { sample: 0.123456789121212121212 },
+    ],
+    [
+      `time stamp`,
+      [0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00],
+      {
+        stamp: {
+          sec: 0,
+          nanosec: 1,
+        },
+      },
+    ],
+    [
+      `duration stamp`,
+      [0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00],
+      {
+        stamp: {
+          sec: 0,
+          nanosec: 1,
+        },
+      },
+    ],
+    [
+      `int32[] arr`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...new Uint8Array(Int32Array.of(3, 7).buffer),
+      ],
+      { arr: Int32Array.from([3, 7]) },
+    ],
+    [
+      `time[1] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 1, nanosec: 2 }] },
+    ],
+    [
+      `duration[1] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 1, nanosec: 2 }] },
+    ],
+    [
+      `time[] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 2, nanosec: 3 }] },
+    ],
+    [
+      `duration[] arr`,
+      [0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      { arr: [{ sec: 2, nanosec: 3 }] },
+    ],
+    // unaligned access
+    [
+      `uint8 blank\nint32[] arr`,
+      [
+        0x00,
+        ...[0x00, 0x00, 0x00], // alignment
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...new Uint8Array(Int32Array.of(3, 7).buffer),
+      ],
+      { blank: 0, arr: Int32Array.from([3, 7]) },
+    ],
+    [
+      `uint8 blank\ntime[] arr`,
+      [
+        0x00,
+        ...[0x00, 0x00, 0x00], // alignment
+        ...[0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00],
+      ],
+      { blank: 0, arr: [{ sec: 2, nanosec: 3 }] },
+    ],
+    [`float32[2] arr`, float32Buffer([5.5, 6.5]), { arr: Float32Array.from([5.5, 6.5]) }],
+    [
+      `uint8 blank\nfloat32[2] arr`,
+      [
+        0x00,
+        ...[0x00, 0x00, 0x00], // alignment
+        ...float32Buffer([5.5, 6.5]),
+      ],
+      { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `float32[] arr`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...float32Buffer([5.5, 6.5]),
+      ],
+      { arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `uint8 blank\nfloat32[] arr`,
+      [
+        0x00,
+        ...[0x00, 0x00, 0x00], // alignment
+        ...[0x02, 0x00, 0x00, 0x00],
+        ...float32Buffer([5.5, 6.5]),
+      ],
+      { blank: 0, arr: Float32Array.from([5.5, 6.5]) },
+    ],
+    [
+      `float32[] first\nfloat32[] second`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...float32Buffer([5.5, 6.5]),
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...float32Buffer([5.5, 6.5]),
+      ],
+      {
+        first: Float32Array.from([5.5, 6.5]),
+        second: Float32Array.from([5.5, 6.5]),
+      },
+    ],
+    [`string sample # empty string`, serializeString(""), { sample: "" }],
+    [`string sample # some string`, serializeString("some string"), { sample: "some string" }],
+    [`int8[4] first`, [0x00, 0xff, 0x80, 0x7f], { first: new Int8Array([0, -1, -128, 127]) }],
+    [
+      `int8[] first`,
+      [
+        ...[0x04, 0x00, 0x00, 0x00], // length
+        0x00,
+        0xff,
+        0x80,
+        0x7f,
+      ],
+      { first: new Int8Array([0, -1, -128, 127]) },
+    ],
+    [`uint8[4] first`, [0x00, 0xff, 0x80, 0x7f], { first: new Uint8Array([0, -1, -128, 127]) }],
+    [
+      `string[2] first`,
+      [...serializeString("one"), ...serializeString("longer string")],
+      { first: ["one", "longer string"] },
+    ],
+    [
+      `string[] first`,
+      [
+        ...[0x02, 0x00, 0x00, 0x00], // length
+        ...serializeString("one"),
+        ...serializeString("longer string"),
+      ],
+      { first: ["one", "longer string"] },
+    ],
+    // first size value after fixed size value
+    [`int8 first\nint8 second`, [0x80, 0x7f], { first: -128, second: 127 }],
+    [
+      `string first\nint8 second`,
+      [...serializeString("some string"), 0x80],
+      { first: "some string", second: -128 },
+    ],
+    [
+      `CustomType custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [0x02],
+      {
+        custom: { first: 0x02 },
+      },
+    ],
+    [
+      `CustomType[3] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [0x02, 0x03, 0x04],
+      {
+        custom: [{ first: 0x02 }, { first: 0x03 }, { first: 0x04 }],
+      },
+    ],
+    [
+      `CustomType[] custom
+    ============
+    MSG: custom_type/CustomType
+    uint8 first`,
+      [
+        ...[0x03, 0x00, 0x00, 0x00], // length
+        0x02,
+        0x03,
+        0x04,
+      ],
+      {
+        custom: [{ first: 0x02 }, { first: 0x03 }, { first: 0x04 }],
+      },
+    ],
+    // ignore constants
+    [
+      `int8 STATUS_ONE = 1
+       int8 STATUS_TWO = 2
+       int8 status`,
+      [0x02],
+      { status: 2 },
+    ],
+    // An array of custom types which themselves have a custom type
+    // This tests an array's ability to properly size custom types
+    [
+      `CustomType[] custom
+    ============
+    MSG: custom_type/CustomType
+    MoreCustom another
+    ============
+    MSG: custom_type/MoreCustom
+    uint8 field`,
+      [
+        ...[0x03, 0x00, 0x00, 0x00], // length
+        0x02,
+        0x03,
+        0x04,
+      ],
+      {
+        custom: [
+          { another: { field: 0x02 } },
+          { another: { field: 0x03 } },
+          { another: { field: 0x04 } },
+        ],
+      },
+    ],
+  ])(
+    "should deserialize %s with ros2Time",
+    (msgDef: string, arr: Iterable<number>, expected: Record<string, unknown>) => {
+      const buffer = Uint8Array.from([0, 1, 0, 0, ...arr]);
+      const reader = new MessageReader(parseMessageDefinition(msgDef, { ros2: true }), {
+        ros2Time: true,
+      });
+      const read = reader.readMessage(buffer);
+
+      // check that our message matches the object
+      expect(read).toEqual(expected);
+    },
+  );
+
   it("should deserialize a ROS 2 log message", () => {
     const buffer = Uint8Array.from(
       Buffer.from(
@@ -304,6 +567,46 @@ describe("MessageReader", () => {
 
     expect(read).toEqual({
       stamp: { sec: 1585866235, nsec: 112130688 },
+      level: 20,
+      name: "minimal_publisher",
+      msg: "Publishing: 'Hello, world! 0'",
+      file: "/opt/ros2_ws/eloquent/src/ros2/examples/rclcpp/minimal_publisher/lambda.cpp",
+      function: "operator()",
+      line: 38,
+    });
+  });
+
+  it("should deserialize a ROS 2 log message w/ ROS 2 time", () => {
+    const buffer = Uint8Array.from(
+      Buffer.from(
+        "00010000fb65865e80faae0614000000120000006d696e696d616c5f7075626c69736865720000001e0000005075626c697368696e673a202748656c6c6f2c20776f726c64212030270000004c0000002f6f70742f726f73325f77732f656c6f7175656e742f7372632f726f73322f6578616d706c65732f72636c6370702f6d696e696d616c5f7075626c69736865722f6c616d6264612e637070000b0000006f70657261746f722829007326000000",
+        "hex",
+      ),
+    );
+    const msgDef = `
+    byte DEBUG=10
+    byte INFO=20
+    byte WARN=30
+    byte ERROR=40
+    byte FATAL=50
+    ##
+    ## Fields
+    ##
+    builtin_interfaces/Time stamp
+    uint8 level
+    string name # name of the node
+    string msg # message
+    string file # file the message came from
+    string function # function the message came from
+    uint32 line # line the message came from
+    `;
+    const reader = new MessageReader(parseMessageDefinition(msgDef, { ros2: true }), {
+      ros2Time: true,
+    });
+    const read = reader.readMessage(buffer);
+
+    expect(read).toEqual({
+      stamp: { sec: 1585866235, nanosec: 112130688 },
       level: 20,
       name: "minimal_publisher",
       msg: "Publishing: 'Hello, world! 0'",
@@ -454,7 +757,7 @@ IDL: builtin_interfaces/Time
 module builtin_interfaces {
   struct Time {
     int32 sec;
-    uint32 nanosec;
+    uint32 nsec;
   };
 };
     `;
@@ -465,7 +768,7 @@ module builtin_interfaces {
       transforms: [
         {
           header: {
-            stamp: { sec: 1638821672, nanosec: 836230505 },
+            stamp: { sec: 1638821672, nsec: 836230505 },
             frame_id: "turtle1",
           },
           child_frame_id: "turtle1_ahead",

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -1,5 +1,6 @@
 import { CdrReader } from "@foxglove/cdr";
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
+
 import { Time } from "./types";
 
 export type Deserializer = (reader: CdrReader) => boolean | number | bigint | string | Time;

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -1,6 +1,6 @@
 import { CdrReader } from "@foxglove/cdr";
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
-import { Time } from "@foxglove/rostime";
+import { Time } from "./types";
 
 export type Deserializer = (reader: CdrReader) => boolean | number | bigint | string | Time;
 export type ArrayDeserializer = (
@@ -123,8 +123,8 @@ const deserializers = new Map<string, Deserializer>([
   ["float32", (reader) => reader.float32()],
   ["float64", (reader) => reader.float64()],
   ["string", (reader) => reader.string()],
-  ["time", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
-  ["duration", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
+  ["time", (reader) => ({ sec: reader.int32(), nanosec: reader.uint32() })],
+  ["duration", (reader) => ({ sec: reader.int32(), nanosec: reader.uint32() })],
 ]);
 
 const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
@@ -164,8 +164,8 @@ function readTimeArray(reader: CdrReader, count: number): Time[] {
   const array = new Array<Time>(count);
   for (let i = 0; i < count; i++) {
     const sec = reader.int32();
-    const nsec = reader.uint32();
-    array[i] = { sec, nsec };
+    const nanosec = reader.uint32();
+    array[i] = { sec, nanosec };
   }
   return array;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type Time = {
+  sec: number;
+  nanosec: number;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,4 @@
+export type Ros2Time = {
+  sec: number;
+  nanosec: number;
+};


### PR DESCRIPTION
As the MessageReader is meant to deserialize ROS 2 CDR messages into objects, it should use the ROS 2 Time message schema instead of the ROS 1 message. The only difference is that ROS 2 builtin_interfaces/Time has a field called nanosec instead of nsec. See: (https://docs.ros2.org/galactic/api/builtin_interfaces/msg/Time.html)