### PR TITLE
Improve error message when encountering wstring

### DIFF
--- a/src/MessageReader.test.ts
+++ b/src/MessageReader.test.ts
@@ -520,4 +520,16 @@ module builtin_interfaces {
 
     expect(read).toEqual({ status: 2 });
   });
+
+  it.each(["wstring field", "wstring[] field"])(
+    "should throw exepction when encountering wstring fields",
+    (msgDef) => {
+      const buffer = Uint8Array.from(Buffer.from("00010000000000007b000000", "hex"));
+      const reader = new MessageReader(parseMessageDefinition(msgDef, { ros2: true }));
+
+      expect(() => reader.readMessage(buffer)).toThrow(
+        "wstring is implementation-defined and therefore not supported",
+      );
+    },
+  );
 });

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -125,6 +125,7 @@ const deserializers = new Map<string, Deserializer>([
   ["string", (reader) => reader.string()],
   ["time", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
   ["duration", (reader) => ({ sec: reader.int32(), nsec: reader.uint32() })],
+  ["wstring", throwOnWstring],
 ]);
 
 const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
@@ -142,6 +143,7 @@ const typedArrayDeserializers = new Map<string, ArrayDeserializer>([
   ["string", readStringArray],
   ["time", readTimeArray],
   ["duration", readTimeArray],
+  ["wstring", throwOnWstring],
 ]);
 
 function readBoolArray(reader: CdrReader, count: number): boolean[] {
@@ -168,4 +170,8 @@ function readTimeArray(reader: CdrReader, count: number): Time[] {
     array[i] = { sec, nsec };
   }
   return array;
+}
+
+function throwOnWstring(): never {
+  throw new Error("wstring is implementation-defined and therefore not supported");
 }

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -579,4 +579,26 @@ module builtin_interfaces {
     expect(() => msgWriter.writeMessage({ array: new Float64Array(10) })).not.toThrow();
     expect(() => msgWriter.writeMessage({ array: new Array(10).fill(0) })).not.toThrow();
   });
+
+  it.each([{ isArray: false }, { isArray: true, arrayLength: 10 }])(
+    "should throw exepction when encountering wstring fields",
+    (def) => {
+      const msgDef = [
+        {
+          definitions: [
+            {
+              type: "wstring",
+              name: "array",
+              ...def,
+            },
+          ],
+        },
+      ];
+
+      const msgWriter = new MessageWriter(msgDef);
+      expect(() => msgWriter.writeMessage({ array: [] })).toThrow(
+        "wstring is implementation-defined and therefore not supported",
+      );
+    },
+  );
 });

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -50,6 +50,7 @@ const PRIMITIVE_WRITERS = new Map<string, PrimitiveWriter>([
   ["string", string],
   ["time", time],
   ["duration", time],
+  ["wstring", throwOnWstring],
 ]);
 
 const PRIMITIVE_ARRAY_WRITERS = new Map<string, PrimitiveArrayWriter>([
@@ -67,7 +68,12 @@ const PRIMITIVE_ARRAY_WRITERS = new Map<string, PrimitiveArrayWriter>([
   ["string", stringArray],
   ["time", timeArray],
   ["duration", timeArray],
+  ["wstring", throwOnWstring],
 ]);
+
+function throwOnWstring(): never {
+  throw new Error("wstring is implementation-defined and therefore not supported");
+}
 
 /**
  * Takes a parsed message definition and returns a message writer which
@@ -260,6 +266,9 @@ export class MessageWriter {
   private getPrimitiveSize(primitiveType: string) {
     const size = PRIMITIVE_SIZES.get(primitiveType);
     if (size == undefined) {
+      if (primitiveType === "wstring") {
+        throwOnWstring();
+      }
       throw new Error(`Unrecognized primitive type ${primitiveType}`);
     }
     return size;


### PR DESCRIPTION
### Changelog
None, at least nothing worth mentionning

### Docs
None

### Description
Throws with a clearer error message when encountering `wstring` fields. Before, the error raised would simply be `Unrecognized primitive type wstring`.
