### PR TITLE
Fix empty message handling for constant-only messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foxglove/rosmsg2-serialization",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "ROS 2 (Robot Operating System) message serialization, for reading and writing bags and network messages",
   "license": "MIT",
   "keywords": [

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -2,6 +2,8 @@ import { CdrReader } from "@foxglove/cdr";
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 import { Time as Ros1Time } from "@foxglove/rostime";
 
+import { messageDefinitionHasData } from "./messageDefinitionHasData";
+
 type Ros2Time = {
   sec: number;
   nanosec: number;
@@ -73,7 +75,7 @@ export class MessageReader<T = unknown> {
   ): Record<string, unknown> {
     const msg: Record<string, unknown> = {};
 
-    if (definition.length === 0) {
+    if (!messageDefinitionHasData(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.

--- a/src/MessageReader.ts
+++ b/src/MessageReader.ts
@@ -2,7 +2,7 @@ import { CdrReader } from "@foxglove/cdr";
 import { MessageDefinition, MessageDefinitionField } from "@foxglove/message-definition";
 import { Time as Ros1Time } from "@foxglove/rostime";
 
-import { messageDefinitionHasData } from "./messageDefinitionHasData";
+import { messageDefinitionHasDataFields } from "./messageDefinitionHasDataFields";
 
 type Ros2Time = {
   sec: number;
@@ -75,7 +75,7 @@ export class MessageReader<T = unknown> {
   ): Record<string, unknown> {
     const msg: Record<string, unknown> = {};
 
-    if (!messageDefinitionHasData(definition)) {
+    if (!messageDefinitionHasDataFields(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.

--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -495,8 +495,24 @@ module builtin_interfaces {
     expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
   });
 
-  it("should serialize a custom msg with a std_msgs/msg/Empty field", () => {
-    const expected = Uint8Array.from(Buffer.from("00010000000000007b000000", "hex"));
+  it("should serialize a custom msg with a std_msgs/msg/Empty field followed by uint8", () => {
+    const expected = Uint8Array.from(Buffer.from("00010000007b", "hex"));
+    const msgDef = `
+    std_msgs/msg/Empty empty
+    uint8 uint_8_field
+    ================================================================================
+    MSG: std_msgs/msg/Empty
+    `;
+    const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
+    const message = { uint_8_field: 123 };
+    const written = writer.writeMessage(message);
+
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
+
+  it("should serialize a custom msg with a std_msgs/msg/Empty field followed by int32", () => {
+    const expected = Uint8Array.from(Buffer.from("00010000000000007b000001", "hex"));
     const msgDef = `
     std_msgs/msg/Empty empty
     int32 int_32_field
@@ -504,7 +520,24 @@ module builtin_interfaces {
     MSG: std_msgs/msg/Empty
     `;
     const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
-    const message = { int_32_field: 123 };
+    const message = { int_32_field: 16777339 };
+    const written = writer.writeMessage(message);
+
+    expect(written).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
+
+  it("should serialize a custom msg withan empty message (with constants) followed by int32", () => {
+    const expected = Uint8Array.from(Buffer.from("00010000000000007b000001", "hex"));
+    const msgDef = `
+    custom_msgs/msg/Nothing empty
+    int32 int_32_field
+    ================================================================================
+    MSG: custom_msgs/msg/Nothing
+    int32 EXAMPLE=123
+    `;
+    const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
+    const message = { int_32_field: 16777339 };
     const written = writer.writeMessage(message);
 
     expect(written).toBytesEqual(expected);

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -5,7 +5,7 @@ import {
   MessageDefinitionField,
 } from "@foxglove/message-definition";
 
-import { messageDefinitionHasData } from "./messageDefinitionHasData";
+import { messageDefinitionHasDataFields } from "./messageDefinitionHasDataFields";
 
 type PrimitiveWriter = (
   value: unknown,
@@ -121,7 +121,7 @@ export class MessageWriter {
     const messageObj = message as Record<string, unknown> | undefined;
     let newOffset = offset;
 
-    if (!messageDefinitionHasData(definition)) {
+    if (!messageDefinitionHasDataFields(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.
@@ -195,7 +195,7 @@ export class MessageWriter {
   #write(definition: MessageDefinitionField[], message: unknown, writer: CdrWriter): void {
     const messageObj = message as Record<string, unknown> | undefined;
 
-    if (!messageDefinitionHasData(definition)) {
+    if (!messageDefinitionHasDataFields(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -5,6 +5,8 @@ import {
   MessageDefinitionField,
 } from "@foxglove/message-definition";
 
+import { messageDefinitionHasData } from "./messageDefinitionHasData";
+
 type PrimitiveWriter = (
   value: unknown,
   defaultValue: DefaultValue,
@@ -119,7 +121,7 @@ export class MessageWriter {
     const messageObj = message as Record<string, unknown> | undefined;
     let newOffset = offset;
 
-    if (definition.length === 0) {
+    if (!messageDefinitionHasData(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.
@@ -193,7 +195,7 @@ export class MessageWriter {
   #write(definition: MessageDefinitionField[], message: unknown, writer: CdrWriter): void {
     const messageObj = message as Record<string, unknown> | undefined;
 
-    if (definition.length === 0) {
+    if (!messageDefinitionHasData(definition)) {
       // In case a message definition definition is empty, ROS 2 adds a
       // `uint8 structure_needs_at_least_one_member` field when converting to IDL,
       // to satisfy the requirement from IDL of not being empty.

--- a/src/messageDefinitionHasData.ts
+++ b/src/messageDefinitionHasData.ts
@@ -1,0 +1,5 @@
+import { MessageDefinitionField } from "@foxglove/message-definition";
+
+export function messageDefinitionHasData(fields: MessageDefinitionField[]): boolean {
+  return fields.some((field) => field.isConstant !== true);
+}

--- a/src/messageDefinitionHasDataFields.ts
+++ b/src/messageDefinitionHasDataFields.ts
@@ -1,5 +1,5 @@
 import { MessageDefinitionField } from "@foxglove/message-definition";
 
-export function messageDefinitionHasData(fields: MessageDefinitionField[]): boolean {
+export function messageDefinitionHasDataFields(fields: MessageDefinitionField[]): boolean {
   return fields.some((field) => field.isConstant !== true);
 }


### PR DESCRIPTION
### Changelog
- Fixed a bug where messages containing only constants were not correctly serialized/deserialized.

### Description

Follow-up to https://github.com/foxglove/rosmsg2-serialization/pull/16. I found that this fix was only made for completely empty message definitions, but it also needs to apply when a message has only constant fields.

Related: FG-9334