### PR TITLE
Fix incorrect array default values

### DIFF
--- a/src/MessageWriter.test.ts
+++ b/src/MessageWriter.test.ts
@@ -635,4 +635,67 @@ module builtin_interfaces {
       );
     },
   );
+
+  it("should serialize a ROS 2 rcl_interfaces/srv/SetParameters Request with default values", () => {
+    // The expected serialized message below was generated with the following python script:
+    // ```py
+    // from rclpy.serialization import serialize_message
+    // from rcl_interfaces.srv import SetParameters
+    // from rcl_interfaces.msg import Parameter, ParameterValue, ParameterType
+    // request = SetParameters.Request()
+    // request.parameters = [
+    //     Parameter(name='foo', value=ParameterValue(type=ParameterType.PARAMETER_INTEGER, integer_value=42)),
+    //     Parameter(name='bar', value=ParameterValue(type=ParameterType.PARAMETER_STRING, string_value="baz")),
+    // ]
+    // print(serialize_message(request).hex())
+    // ```
+    const expected = Uint8Array.from(
+      Buffer.from(
+        "000100000200000004000000666f6f00020000002a00000000000000000000000000000001000000000000000000000000000000000000000000000000000000040000006261720004000000000000000000000000000000000000000400000062617a00000000000000000000000000000000000000000000000000000000000000000000000000",
+        "hex",
+      ),
+    );
+    const msgDef = `
+    Parameter[] parameters
+    ================================================================================
+    MSG: rcl_interfaces/msg/Parameter
+    string name
+    ParameterValue value
+    ================================================================================
+    MSG: rcl_interfaces/msg/ParameterValue
+    uint8 type
+    bool bool_value
+    int64 integer_value
+    float64 double_value
+    string string_value
+    byte[] byte_array_value
+    bool[] bool_array_value
+    int64[] integer_array_value
+    float64[] double_array_value
+    string[] string_array_value
+    `;
+
+    const writer = new MessageWriter(parseMessageDefinition(msgDef, { ros2: true }));
+    const message = {
+      parameters: [
+        {
+          name: "foo",
+          value: {
+            type: 2,
+            integer_value: 42,
+          },
+        },
+        {
+          name: "bar",
+          value: {
+            type: 4,
+            string_value: "baz",
+          },
+        },
+      ],
+    };
+    const written = writer.writeMessage(message);
+    expect(written.buffer).toBytesEqual(expected);
+    expect(writer.calculateByteSize(message)).toEqual(expected.byteLength);
+  });
 });

--- a/src/MessageWriter.ts
+++ b/src/MessageWriter.ts
@@ -384,7 +384,7 @@ function boolArray(
     const array = new Int8Array(value);
     writer.int8Array(array);
   } else {
-    writer.int8Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.int8Array((defaultValue ?? new Int8Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -400,7 +400,7 @@ function int8Array(
     const array = new Int8Array(value);
     writer.int8Array(array);
   } else {
-    writer.int8Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.int8Array((defaultValue ?? new Int8Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -418,7 +418,7 @@ function uint8Array(
     const array = new Uint8Array(value);
     writer.uint8Array(array);
   } else {
-    writer.uint8Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.uint8Array((defaultValue ?? new Uint8Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -434,7 +434,7 @@ function int16Array(
     const array = new Int16Array(value);
     writer.int16Array(array);
   } else {
-    writer.int16Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.int16Array((defaultValue ?? new Int16Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -450,7 +450,7 @@ function uint16Array(
     const array = new Uint16Array(value);
     writer.uint16Array(array);
   } else {
-    writer.uint16Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.uint16Array((defaultValue ?? new Uint16Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -466,7 +466,7 @@ function int32Array(
     const array = new Int32Array(value);
     writer.int32Array(array);
   } else {
-    writer.int32Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.int32Array((defaultValue ?? new Int32Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -482,7 +482,7 @@ function uint32Array(
     const array = new Uint32Array(value);
     writer.uint32Array(array);
   } else {
-    writer.uint32Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.uint32Array((defaultValue ?? new Uint32Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -498,7 +498,7 @@ function int64Array(
     const array = new BigInt64Array(value);
     writer.int64Array(array);
   } else {
-    writer.int64Array((defaultValue ?? new Array(arrayLength).fill(0n)) as bigint[]);
+    writer.int64Array((defaultValue ?? new BigInt64Array(arrayLength ?? 0).fill(0n)) as bigint[]);
   }
 }
 
@@ -514,7 +514,7 @@ function uint64Array(
     const array = new BigUint64Array(value);
     writer.uint64Array(array);
   } else {
-    writer.uint64Array((defaultValue ?? new Array(arrayLength).fill(0n)) as bigint[]);
+    writer.uint64Array((defaultValue ?? new BigUint64Array(arrayLength ?? 0).fill(0n)) as bigint[]);
   }
 }
 
@@ -530,7 +530,7 @@ function float32Array(
     const array = new Float32Array(value);
     writer.float32Array(array);
   } else {
-    writer.float32Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.float32Array((defaultValue ?? new Float32Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -546,7 +546,7 @@ function float64Array(
     const array = new Float64Array(value);
     writer.float64Array(array);
   } else {
-    writer.float64Array((defaultValue ?? new Array(arrayLength).fill(0)) as number[]);
+    writer.float64Array((defaultValue ?? new Float64Array(arrayLength ?? 0).fill(0)) as number[]);
   }
 }
 
@@ -561,7 +561,7 @@ function stringArray(
       writer.string(typeof item === "string" ? item : "");
     }
   } else {
-    const array = (defaultValue ?? new Array(arrayLength).fill("")) as string[];
+    const array = (defaultValue ?? new Array(arrayLength ?? 0).fill("")) as string[];
     for (const item of array) {
       writer.string(item);
     }


### PR DESCRIPTION
### Changelog
Fix incorrect serialization when values for array fields are not specified

### Docs
None

### Description
When a message that is to be serialized contains less fields than the given schema, the MessageWriter will take the default value for the missing fields. For arrays of non-fixed length, the default value is an empty array. However, prior to this PR, the default value for these arrays was not `[]` but an array with a single element. This was caused by having the array length being undefined in the Array constructor:

```
new Array(undefined).fill(0)
-> [0]
```

Changing this as shown below fixes the issue:
```
new Array(undefined ?? 0).fill(0)
-> []
```


